### PR TITLE
Dockerfile to provide a docker image for running benchmarks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+#
+# Quick and dirty contained environement for runnning a ServerBear benchmark
+#
+# Reference:
+# * http://www.serverbear.com
+# * https://github.com/Crowd9/Benchmark
+#
+FROM ubuntu:14.04
+
+MAINTAINER Kyle Manna <kyle@kylemanna.com>
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ADD sb.sh /usr/local/bin/
+RUN chmod a+x /usr/local/bin/sb.sh && \
+    apt-get update && \
+    apt-get install -y build-essential curl wget traceroute libaio-dev && \
+    apt-get clean && apt-get purge && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENTRYPOINT ["sb.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,7 @@ RUN chmod a+x /usr/local/bin/sb.sh && \
     apt-get clean && apt-get purge && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+VOLUME ["/test"]
+WORKDIR /test
+
 ENTRYPOINT ["sb.sh"]

--- a/README
+++ b/README
@@ -23,3 +23,9 @@ wget -N https://raw.github.com/Crowd9/Benchmark/master/sb.sh&&bash sb.sh 'Web Ho
 Example:
 
 wget -N https://raw.github.com/Crowd9/Benchmark/master/sb.sh&&bash sb.sh 'Linode' 'Linode 512' 'storecrowd@mailinator.com' '19.99'
+
+
+Docker Usage
+------------
+
+    docker run --rm -it kylemanna/serverbear 'Linode' 'Linode 512' 'storecrowd@mailinator.com' '19.99'


### PR DESCRIPTION
This approach allows the benchmark to occur in a docker container which will be removed upon completion and won't add cruft to the servers under test.